### PR TITLE
Refactor phase change logic.

### DIFF
--- a/src/pugbot/commands/add.rs
+++ b/src/pugbot/commands/add.rs
@@ -3,18 +3,14 @@ use serenity::model::user::User;
 
 use consume_message;
 use models::game::{Game, Phases};
-use queue_size;
 use traits::has_members::HasMembers;
 use traits::phased::Phased;
 use traits::pool_availability::PoolAvailability;
 
 command!(add(ctx, msg) {
-  {
-    let mut data = ctx.data.lock();
-    let game = data.get_mut::<Game>().unwrap();
-
-    update_members(game, msg, true);
-  }
+  let mut data = ctx.data.lock();
+  let game = data.get_mut::<Game>().unwrap();
+  update_members(game, msg, true);
 });
 
 pub fn update_members(
@@ -38,13 +34,6 @@ pub fn update_members(
       }
     }
   }
-
-  let members = game.draft_pool.members();
-  if members.len() as u32 == queue_size()
-    && game.phase == Some(Phases::PlayerRegistration)
-  {
-    game.next_phase();
-  }
-
-  members
+  game.next_phase();
+  game.draft_pool.members()
 }

--- a/src/pugbot/commands/pick.rs
+++ b/src/pugbot/commands/pick.rs
@@ -17,7 +17,7 @@ command!(pick(ctx, msg, args) {
   let user = game.draft_pool.pop_available_player(&user_index).unwrap();
   game.next_team_to_draft().add_member(user);
 
-  let max_turns: u32 = queue_size() - team_count().unwrap();
+  let max_turns: u32 = queue_size() - team_count();
 
   if game.turn_number == max_turns as usize {
     game.next_phase();
@@ -26,5 +26,4 @@ command!(pick(ctx, msg, args) {
   } else {
     game.turn_number += 1;
   }
-
 });

--- a/src/pugbot/commands/remove.rs
+++ b/src/pugbot/commands/remove.rs
@@ -73,6 +73,8 @@ mod tests {
       DraftPool::new(vec![gen_test_user(Some(message.author.id))]),
       1,
       Vec::new(),
+      2,
+      6,
     );
     assert_eq!(game.phase, Some(Phases::PlayerRegistration));
     let members = commands::remove::remove_member(game, &message, false);


### PR DESCRIPTION
The goal is to move all "Should a phase change be executed?" logic to the
`next_phase` match expression. This patch does that for just the `add` command.

It may help to understand the `add` command. This command is executed when a
user types `.add` in Discord chat. A user will do this when they want to be
added to the pool of players available for drafting into a team. The phase
where players add themselves is called `PlayerRegistration`. For obvious
reasons, we do not want to move from `PlayerRegistration` to the next
phase (`CaptainSelection`) until the draft pool[1] is full.

So in order to determine whether the next phase should be entered, we want to
check the number of users in the draft pool against the max size of the draft
pool. If the two are equal, then we phase-change.

Prior to this patch, that checking logic existed in the `add` command
itself. This patch moves that logic into the match expression in the
`next_phase` implementation on `Game`. I believe this
approach makes the code easier to reason about due to better separation of
concerns.

References #23 

[1] Draft pool size is determined by `TEAM_COUNT * TEAM_SIZE`, which are two
environmental variables set in the `.env` file.