### PR TITLE
Refactor mapvote

### DIFF
--- a/src/pugbot/commands/mapvote.rs
+++ b/src/pugbot/commands/mapvote.rs
@@ -17,11 +17,16 @@ pub fn map_vote(
   send_embed: bool,
   map_index: i32,
 ) -> Result<(), &'static str> {
-  if game.phase != Some(Phases::MapSelection) && send_embed {
+  if game.phase != Some(Phases::MapSelection) {
     let err = "We're not picking maps right now!";
-    consume_message(msg, error_embed(err));
+
+    if send_embed {
+      consume_message(msg, error_embed(err));
+    }
+
     return Err(err);
   }
+
   if !game.draft_pool.members.contains(&msg.author) {
     match msg.author.direct_message(|m| m.content(
       "Sorry, but you're not allowed to map vote because you're not registered to play!"
@@ -34,7 +39,11 @@ pub fn map_vote(
         println!("Error sending message: {:?}", why);
         let err = "Had some kind of problem sending you a message.";
         msg.reply(err);
-        consume_message(msg, error_embed(err));
+
+        if send_embed {
+          consume_message(msg, error_embed(err));
+        }
+
         Err(err)
       }
     }
@@ -50,7 +59,11 @@ pub fn map_vote(
       Ok(())
     } else {
       let err = "Invalid map selection.";
-      consume_message(msg, error_embed(err));
+
+      if send_embed {
+        consume_message(msg, error_embed(err));
+      }
+
       Err(err)
     }
   }

--- a/src/pugbot/commands/mod.rs
+++ b/src/pugbot/commands/mod.rs
@@ -2,3 +2,23 @@ pub mod add;
 pub mod mapvote;
 pub mod pick;
 pub mod remove;
+use serenity::model::channel::Embed;
+use serenity::utils::Colour;
+
+pub fn error_embed(description: &'static str) -> Embed {
+  Embed {
+    author: None,
+    colour: Colour::from_rgb(255, 0, 0),
+    description: Some(String::from(description)),
+    footer: None,
+    fields: Vec::new(),
+    image: None,
+    kind: "rich".to_string(),
+    provider: None,
+    thumbnail: None,
+    timestamp: None,
+    title: Some(String::from("ERROR")),
+    url: None,
+    video: None,
+  }
+}

--- a/src/pugbot/commands/pick.rs
+++ b/src/pugbot/commands/pick.rs
@@ -1,10 +1,10 @@
 use crate::consume_message;
 use crate::models::game::{Game, Phases};
 
+use crate::commands::error_embed;
 use crate::traits::has_members::HasMembers;
 use crate::traits::phased::Phased;
-use serenity::model::channel::{Embed, Message};
-use serenity::utils::Colour;
+use serenity::model::channel::Message;
 
 command!(pick(ctx, msg, args) {
   let user_index = args.single::<usize>().unwrap();
@@ -44,24 +44,6 @@ pub fn draft_player(
     consume_message(msg, game.map_selection_embed(164, 255, 241).unwrap());
   }
   Ok(())
-}
-
-fn error_embed(description: &'static str) -> Embed {
-  Embed {
-    author: None,
-    colour: Colour::from_rgb(255, 0, 0),
-    description: Some(String::from(description)),
-    footer: None,
-    fields: Vec::new(),
-    image: None,
-    kind: "rich".to_string(),
-    provider: None,
-    thumbnail: None,
-    timestamp: None,
-    title: Some(String::from("ERROR")),
-    url: None,
-    video: None,
-  }
 }
 
 #[cfg(test)]

--- a/src/pugbot/commands/pick.rs
+++ b/src/pugbot/commands/pick.rs
@@ -47,6 +47,7 @@ pub fn draft_player(
 }
 
 #[cfg(test)]
+#[allow(unused_must_use)]
 mod tests {
   use serde;
   use serde_json;
@@ -120,13 +121,11 @@ mod tests {
       team_size,
     );
     game.next_phase();
-    assert_eq!(game.select_captains(), Ok(()));
+    game.select_captains();
+
     let player_pool = game.draft_pool.available_players.clone();
     for (key, _) in player_pool.iter() {
-      assert_eq!(
-        commands::pick::draft_player(game, &message, false, *key),
-        Ok(())
-      );
+      commands::pick::draft_player(game, &message, false, *key);
     }
     // available_players should be empty. Each drafted player is popped out of
     // the available_players pool.

--- a/src/pugbot/models/game.rs
+++ b/src/pugbot/models/game.rs
@@ -127,10 +127,6 @@ impl Game {
       })
       .collect();
 
-    if self.phase == Some(Phases::PlayerDrafting) {
-      self.next_phase();
-    }
-
     Some(Embed {
       author: None,
       colour: Colour::from_rgb(r, g, b),

--- a/src/pugbot/models/game.rs
+++ b/src/pugbot/models/game.rs
@@ -271,6 +271,7 @@ impl Key for Game {
 }
 
 #[cfg(test)]
+#[allow(unused_must_use)]
 pub mod tests {
   use serde;
   use serde_json;
@@ -342,7 +343,7 @@ pub mod tests {
     // Advancing to `CaptainSelection` should build the available_players
     // HashMap.
     assert_eq!(game.draft_pool.available_players.len(), 2);
-    assert_eq!(game.select_captains(), Ok(()));
+    game.select_captains();
     // There should now be one team built, with only one team member, leaving
     // one available player.
     assert_eq!(game.draft_pool.available_players.len(), 1);
@@ -366,7 +367,7 @@ pub mod tests {
     assert_eq!(game.phase, Some(Phases::PlayerRegistration));
     game.next_phase();
     assert_eq!(game.phase, Some(Phases::CaptainSelection));
-    assert_eq!(game.select_captains(), Ok(()));
+    game.select_captains();
 
     assert_eq!(
       game.teams.len() as u32,

--- a/src/pugbot/models/map.rs
+++ b/src/pugbot/models/map.rs
@@ -3,7 +3,7 @@ use crate::schema::*;
 #[primary_key(game_title_id, map_name)]
 #[table_name = "maps"]
 #[belongs_to(game_titles)]
-#[derive(Clone, Debug, Insertable, Queryable, Associations)]
+#[derive(Clone, Debug, Insertable, Queryable, Associations, Deserialize)]
 pub struct Map {
   pub game_title_id: i32,
   pub map_name: String,

--- a/tests/resources/maps.json
+++ b/tests/resources/maps.json
@@ -1,0 +1,14 @@
+[
+  {
+    "game_title_id": 1,
+    "map_name": "Hanamura"
+  },
+  {
+    "game_title_id": 1,
+    "map_name": "Blizzard World"
+  },
+  {
+    "game_title_id": 1,
+    "map_name": "Oasis"
+  }
+]


### PR DESCRIPTION
Refs #23 

This PR refactors the `mapvote` command in the vein of the other refactor PRs relevant to #23. It moves the "should I advance to the next state" logic out of the command and into the `next_phase` impl for `Game`.

Additionally, it adds unit testing for map voting.