### PR TITLE
Rework `client_setup()`.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,5 +5,6 @@ fn main() {
   // This will load the environment variables located at `./.env`, relative to
   // the CWD. See `./.env.example` for an example on how to structure this.
   kankyo::load().expect("Failed to load .env file");
-  pugbot::client_setup();
+  // FIXME: needs an async executor to run
+  let _ = pugbot::client_setup().await;
 }

--- a/src/pugbot/commands/add.rs
+++ b/src/pugbot/commands/add.rs
@@ -10,9 +10,12 @@ use crate::traits::pool_availability::PoolAvailability;
 use serenity::framework::standard::CommandResult;
 use serenity::prelude::Context;
 
-// FIXME: Fill in the details for these attributes:
-//  <https://docs.rs/serenity/0.10.5/serenity/framework/standard/macros/attr.command.html#options>
 #[command]
+#[aliases("a")]
+#[description(r#"Adds yourself to the pool of draftable players, or "draft pool."
+
+Once enough people to fill out all the teams have added themselves, captains will be automatically selected at random, and drafting will begin."#
+)]
 pub(crate) async fn add(ctx: &Context, msg: &Message) -> CommandResult {
   let mut data = ctx.data.lock();
   let game = data.get_mut::<Game>().unwrap();

--- a/src/pugbot/commands/mapvote.rs
+++ b/src/pugbot/commands/mapvote.rs
@@ -8,6 +8,8 @@ use serenity::model::channel::Message;
 use serenity::prelude::Context;
 
 #[command]
+#[aliases("v", "mv")]
+#[description("Records your vote for map selection")]
 pub(crate) async fn mapvote(
   ctx: &Context,
   msg: &Message,

--- a/src/pugbot/commands/mod.rs
+++ b/src/pugbot/commands/mod.rs
@@ -2,8 +2,19 @@ pub mod add;
 pub mod mapvote;
 pub mod pick;
 pub mod remove;
+use add::ADD_COMMAND;
+use mapvote::MAPVOTE_COMMAND;
+use pick::PICK_COMMAND;
+use remove::REMOVE_COMMAND;
+use serenity::framework::standard::macros::{group, help};
+use serenity::framework::standard::{
+  help_commands, Args, CommandGroup, CommandResult, HelpOptions,
+};
 use serenity::model::channel::Embed;
+use serenity::model::prelude::{Message, UserId};
+use serenity::prelude::Context;
 use serenity::utils::Colour;
+use std::collections::HashSet;
 
 pub fn error_embed(description: &'static str) -> Embed {
   Embed {
@@ -21,4 +32,58 @@ pub fn error_embed(description: &'static str) -> Embed {
     url: None,
     video: None,
   }
+}
+
+// These groups really beg to be defined within the same module as the
+// commands they are grouping.
+// The "names" in the `#[commands]` attr is transformed into an all-caps version
+// with a `_COMMAND` suffix, which needs to be explicitly brought into scope,
+// unless of course everything happens to be in the same module to begin with.
+//
+// Similarly, the output from these `#[group]` attr macros will be all-caps
+// versions of the unit structs defined here, but with a `_GROUP` suffix.
+//
+// Ideally, all this code would be reshaped such that the need to import the
+// mangled names is reduced. This could be achieved by arranging the modules
+// based on groups first, then commands. Finally, the framework config could
+// happen via functions in each group's module that receive and return a
+// `StandardFramework`, each adding their groups to the config.
+
+#[group("Player Registration")]
+#[commands(add, remove)]
+pub(crate) struct PlayerRegistration;
+
+#[group("Player Drafting")]
+#[description("Commands here are available to Captains only")]
+#[commands(pick)]
+pub(crate) struct PlayerDrafting;
+
+#[group("Map Voting")]
+#[commands(mapvote)]
+pub(crate) struct MapVoting;
+
+// XXX: From reading the serenity docs, honestly it's unclear if this is needed
+// or if we're reimplementing whatever the default behavior is.
+// Regardless, we can't simply feed `help_commands::with_embeds()` to the
+// `StandardFramework::help()` method since the types do not align.
+// It demands whatever the output is from this `#[help]` attr macro.
+#[help]
+pub(crate) async fn help_cmd(
+  context: &Context,
+  msg: &Message,
+  args: Args,
+  help_options: &'static HelpOptions,
+  groups: &[&'static CommandGroup],
+  owners: HashSet<UserId>,
+) -> CommandResult {
+  let _ = help_commands::with_embeds(
+    context,
+    msg,
+    args,
+    help_options,
+    groups,
+    owners,
+  )
+  .await;
+  Ok(())
 }

--- a/src/pugbot/commands/pick.rs
+++ b/src/pugbot/commands/pick.rs
@@ -9,7 +9,25 @@ use serenity::framework::standard::{Args, CommandResult};
 use serenity::model::channel::Message;
 use serenity::prelude::Context;
 
+// FIXME: look at the `#[allow_roles()]` attr to restrict this to captains.
 #[command]
+#[aliases("p")]
+#[description(r#"(Captains Only) `pick #` adds player `#` to your team.
+
+Once enough players to fill out all the teams have added themselves, captains will be automatically selected at random. One captain will be selected per team.
+
+The bot will then display a numbered list of players, like so:
+
+```
+  Index     Player Name
+----------|-------------
+    1     | Alice
+    2     | Bob
+    3     | Charlie
+```
+
+Captains will be able to use the `~pick <index>` command."#
+)]
 pub(crate) async fn pick(
   ctx: &Context,
   msg: &Message,

--- a/src/pugbot/commands/remove.rs
+++ b/src/pugbot/commands/remove.rs
@@ -8,6 +8,8 @@ use serenity::model::user::User;
 use serenity::prelude::Context;
 
 #[command]
+#[aliases("r")]
+#[description("Removes yourself from the draft pool.")]
 pub(crate) async fn remove(ctx: &Context, msg: &Message) -> CommandResult {
   let mut data = ctx.data.lock();
   let mut game = data.get_mut::<Game>().unwrap();


### PR DESCRIPTION
This diff focuses on closing the API gap for serenity for the
initialization of the "framework" code.

Ironically, the previous PR that focused on commands ended up being
insufficient and much of the setup code refactored here ended up being moved
down into the command module(s).

Noted in the code comments for `pugbot::commands`, many of the macros
the serenity framework use rely on name mangling, which sort of begs us
to build up groups, commands, and configure them in the framework within
a single module's scope (so as to avoid having to import the mangled
names in our app code). I don't have a solid recommendation just yet,
but floated some weak ideas in the comments.